### PR TITLE
[WIP] Make the new module system in rdflib work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1637,9 +1637,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -6325,13 +6325,13 @@
       }
     },
     "jsonld": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
-      "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
+      "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
       "requires": {
-        "es6-promise": "^2.0.0",
-        "pkginfo": "~0.4.0",
-        "request": "^2.61.0",
+        "rdf-canonize": "^1.0.2",
+        "request": "^2.88.0",
+        "semver": "^5.6.0",
         "xmldom": "0.1.19"
       },
       "dependencies": {
@@ -7103,9 +7103,9 @@
       "dev": true
     },
     "n3": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-0.4.5.tgz",
-      "integrity": "sha1-W3DTq2ohyejUyb2io9TZCQm+tQg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.2.0.tgz",
+      "integrity": "sha512-3VZD31lRyG2JoAa7imyhAIUZbqaZk4FSsa5QenNjUhNNJKomMLcwuhAOyl+i/suT7UB2H16Ta/7tSUP+Hkq/EQ=="
     },
     "nan": {
       "version": "2.14.0",
@@ -8216,17 +8216,17 @@
       }
     },
     "rdflib": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.21.1.tgz",
-      "integrity": "sha512-NGcKNkeHCUKQwpbkmmNzcm+QwveCZSdb11EbaVW7XGMCwDrHni6f1AbqD5Hy0pdzRfMmidkAerORbsj02oPSdw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-1.0.3.tgz",
+      "integrity": "sha512-6sj5WfjPaXpK4l4QP/HAgF7BnDG2FMKHPq0Sx57qt3vO+vrtn1Cf9Je1SXIUMg4A71KcVFF726aikeH0W33EAg==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "async": "^0.9.x",
-        "jsonld": "^0.4.5",
-        "n3": "^0.4.1",
-        "solid-auth-cli": "^0.1.12",
+        "@babel/runtime": "^7.5.5",
+        "async": "^3.1.x",
+        "jsonld": "^1.6.2",
+        "n3": "^1.2.0",
+        "solid-auth-cli": "^1.0.8",
         "solid-auth-client": "^2.3.0",
-        "xmldom": "^0.1.22"
+        "xmldom": "^0.1.27"
       }
     },
     "read-pkg": {
@@ -9140,16 +9140,16 @@
       }
     },
     "solid-auth-cli": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/solid-auth-cli/-/solid-auth-cli-0.1.14.tgz",
-      "integrity": "sha512-G1xhi4hASPW5hib1UxN10rm0X2lTYqqNQELJ4neRjcM07qWnkKUG08Q4fMFz5xeKAWjDh8ytqhvq5M349/CZsw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/solid-auth-cli/-/solid-auth-cli-1.0.8.tgz",
+      "integrity": "sha512-cZYNLM6/BDwbcywsrfFRIrGVjTPc/f3snubabqd1WRCvNwW7wkvpo0yvoHp3NQjVAfKHw5kIrZtaV8IRHPK/KQ==",
       "requires": {
         "@solid/cli": "^0.1.1",
         "async": "^2.6.1",
         "isomorphic-fetch": "^2.2.1",
         "jsonld": "^1.4.0",
         "n3": "^1.0.3",
-        "solid-rest": "^1.0.2"
+        "solid-rest": "^1.0.7"
       },
       "dependencies": {
         "async": {
@@ -9159,27 +9159,6 @@
           "requires": {
             "lodash": "^4.17.14"
           }
-        },
-        "jsonld": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
-          "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
-          "requires": {
-            "rdf-canonize": "^1.0.2",
-            "request": "^2.88.0",
-            "semver": "^5.6.0",
-            "xmldom": "0.1.19"
-          }
-        },
-        "n3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/n3/-/n3-1.1.1.tgz",
-          "integrity": "sha512-GEJXn+wc0f4l2noP1N/rMUH9Gei1DQ8IDN03eBsH+uQKkNQUOLgL7ZJVaDjY+pP3LmbLxL1LpUg/AvZ7Kc7KVw=="
-        },
-        "xmldom": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-          "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
         }
       }
     },
@@ -9247,6 +9226,92 @@
         "tslint-config-standard": "^8.0.1"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "jsonld": {
+          "version": "0.4.12",
+          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
+          "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
+          "requires": {
+            "es6-promise": "^2.0.0",
+            "pkginfo": "~0.4.0",
+            "request": "^2.61.0",
+            "xmldom": "0.1.19"
+          },
+          "dependencies": {
+            "xmldom": {
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+              "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+            }
+          }
+        },
+        "n3": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-0.4.5.tgz",
+          "integrity": "sha1-W3DTq2ohyejUyb2io9TZCQm+tQg="
+        },
+        "rdflib": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.21.1.tgz",
+          "integrity": "sha512-NGcKNkeHCUKQwpbkmmNzcm+QwveCZSdb11EbaVW7XGMCwDrHni6f1AbqD5Hy0pdzRfMmidkAerORbsj02oPSdw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "async": "^0.9.x",
+            "jsonld": "^0.4.5",
+            "n3": "^0.4.1",
+            "solid-auth-cli": "^0.1.12",
+            "solid-auth-client": "^2.3.0",
+            "xmldom": "^0.1.22"
+          }
+        },
+        "solid-auth-cli": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/solid-auth-cli/-/solid-auth-cli-0.1.14.tgz",
+          "integrity": "sha512-G1xhi4hASPW5hib1UxN10rm0X2lTYqqNQELJ4neRjcM07qWnkKUG08Q4fMFz5xeKAWjDh8ytqhvq5M349/CZsw==",
+          "requires": {
+            "@solid/cli": "^0.1.1",
+            "async": "^2.6.1",
+            "isomorphic-fetch": "^2.2.1",
+            "jsonld": "^1.4.0",
+            "n3": "^1.0.3",
+            "solid-rest": "^1.0.2"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            },
+            "jsonld": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
+              "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
+              "requires": {
+                "rdf-canonize": "^1.0.2",
+                "request": "^2.88.0",
+                "semver": "^5.6.0",
+                "xmldom": "0.1.19"
+              }
+            },
+            "n3": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/n3/-/n3-1.2.0.tgz",
+              "integrity": "sha512-3VZD31lRyG2JoAa7imyhAIUZbqaZk4FSsa5QenNjUhNNJKomMLcwuhAOyl+i/suT7UB2H16Ta/7tSUP+Hkq/EQ=="
+            },
+            "xmldom": {
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+              "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+            }
+          }
+        },
         "tslint": {
           "version": "5.18.0",
           "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
@@ -9302,10 +9367,96 @@
         "solid-namespace": "0.2.0"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "jsonld": {
+          "version": "0.4.12",
+          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
+          "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
+          "requires": {
+            "es6-promise": "^2.0.0",
+            "pkginfo": "~0.4.0",
+            "request": "^2.61.0",
+            "xmldom": "0.1.19"
+          },
+          "dependencies": {
+            "xmldom": {
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+              "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+            }
+          }
+        },
+        "n3": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-0.4.5.tgz",
+          "integrity": "sha1-W3DTq2ohyejUyb2io9TZCQm+tQg="
+        },
         "node-uuid": {
           "version": "1.4.8",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
           "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "rdflib": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.21.1.tgz",
+          "integrity": "sha512-NGcKNkeHCUKQwpbkmmNzcm+QwveCZSdb11EbaVW7XGMCwDrHni6f1AbqD5Hy0pdzRfMmidkAerORbsj02oPSdw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "async": "^0.9.x",
+            "jsonld": "^0.4.5",
+            "n3": "^0.4.1",
+            "solid-auth-cli": "^0.1.12",
+            "solid-auth-client": "^2.3.0",
+            "xmldom": "^0.1.22"
+          }
+        },
+        "solid-auth-cli": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/solid-auth-cli/-/solid-auth-cli-0.1.14.tgz",
+          "integrity": "sha512-G1xhi4hASPW5hib1UxN10rm0X2lTYqqNQELJ4neRjcM07qWnkKUG08Q4fMFz5xeKAWjDh8ytqhvq5M349/CZsw==",
+          "requires": {
+            "@solid/cli": "^0.1.1",
+            "async": "^2.6.1",
+            "isomorphic-fetch": "^2.2.1",
+            "jsonld": "^1.4.0",
+            "n3": "^1.0.3",
+            "solid-rest": "^1.0.2"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            },
+            "jsonld": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
+              "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
+              "requires": {
+                "rdf-canonize": "^1.0.2",
+                "request": "^2.88.0",
+                "semver": "^5.6.0",
+                "xmldom": "0.1.19"
+              }
+            },
+            "n3": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/n3/-/n3-1.2.0.tgz",
+              "integrity": "sha512-3VZD31lRyG2JoAa7imyhAIUZbqaZk4FSsa5QenNjUhNNJKomMLcwuhAOyl+i/suT7UB2H16Ta/7tSUP+Hkq/EQ=="
+            },
+            "xmldom": {
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+              "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+            }
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,18 +43,10 @@
     "url": "https://github.com/solid/mashlib/issues"
   },
   "homepage": "https://github.com/solid/mashlib",
-  "dependenciesFile": {
-    "rdflib": "file://../../solid/rdflib.js",
-    "solid-panes": "file://../../solid/solid-panes"
-  },
   "dependencies": {
-    "rdflib": "^0.21.1",
+    "rdflib": "^1.0.3",
     "solid-namespace": "^0.2.0",
     "solid-panes": "^1.4.0"
-  },
-  "dependenciesBackup": {
-    "rdflib": ">=0.19.1",
-    "solid-panes": ">=1.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-import $rdf, { NamedNode } from 'rdflib'
+import * as $rdf from 'rdflib'
 import panes from 'solid-panes'
 import './styles/index.scss'
 import { initHeader } from './global/header'
 import { initFooter } from './global/footer'
+import { NamedNode } from 'rdflib'
 
 const global: any = window
 


### PR DESCRIPTION
This should only be merged after https://github.com/linkeddata/rdflib.js/pull/335 is merged and pushed into a new version.

~~Not 100% sure _why_ this works, but seems to do the trick on my local setup.~~

Right, @RubenVerborgh already explained this in his comment https://github.com/linkeddata/rdflib.js/pull/335#issue-307708896

> The only breaking change is that external code that was incorrectly using import rdf from 'rdflib' should use import * as rdf from 'rdflib'. Preferably, such code imports the exposed subcomponents of rdflib, such that tree shaking becomes possible.