### PR TITLE
Publish to npm on every push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
     tag: "$TRAVIS_BRANCH"
     on:
       all_branches: true
+      condition: $TRAVIS_NODE_VERSION = "node"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,23 @@ script:
 
 before_deploy:
   - echo node_modules > .gitignore
+  - node ./travis/bumpversion.js
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GH_TOKEN
-  on:
-    branch: master
-    condition: $TRAVIS_NODE_VERSION = 10.0
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GH_TOKEN
+    on:
+      branch: master
+      condition: $TRAVIS_NODE_VERSION = 10.0
+  - provider: npm
+    # Do not throw away the updated package.json we generated in `before_deploy`:
+    skip_cleanup: true
+    email: "$NPM_EMAIL"
+    api_key: "$NPM_TOKEN"
+    # Note: do not deploy on pull request, because $TRAVIS_BRANCH will be the target branch.
+    tag: "$TRAVIS_BRANCH"
+    on:
+      all_branches: true
 
 cache:
   directories:

--- a/travis/bumpversion.js
+++ b/travis/bumpversion.js
@@ -1,0 +1,19 @@
+/**
+ * npm does not allow you to publish a package with the same version multiple times.
+ * Thus, to publish prerelease versions tagged to the branch they're built from,
+ * we need to generate unique version numbers that are also higher than versions already published.
+ * To achieve this, we append `build<build_number>` to the version number.
+ * The actual release version can eventually be published without the suffix.
+ */
+
+if (!process.env.TRAVIS_BUILD_NUMBER || process.env.TRAVIS_BUILD_NUMBER.length === 0) {
+  console.error('Could not read the build number to bump the package version - aborting publish.')
+  process.exit(1)
+}
+
+const fs = require('fs')
+const path = require('path')
+
+const packageJson = require('../package.json')
+packageJson.version = `${packageJson.version}build${process.env.TRAVIS_BUILD_NUMBER}`
+fs.writeFileSync(path.resolve(__dirname, '../package.json'), JSON.stringify(packageJson))


### PR DESCRIPTION
This should make Ruben happy: whenever a new push to mashlib happens on any branch, it gets published to npm, tagged with the branch name. Thus, NSS could simply `npm install mashlib@master` before deploying to dev.inrupt.net to see whether it works as desired. If it does, we can cut a new release.