### PR TITLE
Making use of UI.authn.findProfileImage (solid-ui)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "normalize.css": "^8.0.1",
     "rdflib": "^1.0.4",
     "solid-namespace": "^0.2.0",
-    "solid-panes": "^2.0.0"
+    "solid-panes": "^2.0.0",
+    "solid-ui": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/global/header.ts
+++ b/src/global/header.ts
@@ -1,7 +1,7 @@
 import $rdf, { IndexedFormula, NamedNode, sym } from "rdflib"
 import namespace from "solid-namespace"
 import panes from "solid-panes"
-import solidUI from "solid-ui"
+import UI from "solid-ui"
 import { icon } from "./icon"
 import { SolidSession } from "../../typings/solid-auth-client"
 import { emptyProfile } from "./empty-profile"
@@ -138,7 +138,7 @@ async function getMenuItems (outliner: any): Promise<Array<{
 }
 
 function getProfileImg (store: IndexedFormula, user: NamedNode): string | HTMLElement {
-  const profileUrl = solidUI.authn.findProfileImage(user)
+  const profileUrl = UI.widgets.findImage(user)
   if (!profileUrl) {
     return emptyProfile
   }

--- a/src/global/header.ts
+++ b/src/global/header.ts
@@ -1,6 +1,7 @@
 import $rdf, { IndexedFormula, NamedNode, sym } from "rdflib"
 import namespace from "solid-namespace"
 import panes from "solid-panes"
+import solidUI from "solid-ui"
 import { icon } from "./icon"
 import { SolidSession } from "../../typings/solid-auth-client"
 import { emptyProfile } from "./empty-profile"
@@ -137,13 +138,13 @@ async function getMenuItems (outliner: any): Promise<Array<{
 }
 
 function getProfileImg (store: IndexedFormula, user: NamedNode): string | HTMLElement {
-  const hasPhoto = (store.anyValue as any)(user, ns.vcard("hasPhoto"), null, user.doc())
-  if (!hasPhoto) {
+  const profileUrl = solidUI.authn.findProfileImage(user)
+  if (!profileUrl) {
     return emptyProfile
   }
   const profileImage = document.createElement("div")
   profileImage.classList.add("header-user-menu__photo")
-  profileImage.style.backgroundImage = `url("${hasPhoto}")`
+  profileImage.style.backgroundImage = `url("${profileUrl}")`
   return profileImage
 }
 

--- a/typings/solid-ui.d.ts
+++ b/typings/solid-ui.d.ts
@@ -1,0 +1,4 @@
+declare module 'solid-ui' {
+  const solidUI: any
+  export default solidUI
+}


### PR DESCRIPTION
Do not merge this until https://github.com/solid/solid-ui/pull/119 is merged and pushed in a new release.

This adds solid-ui as a dependency for mashlib.

Partial fix for https://github.com/solid/solid-panes/issues/169