### PR TITLE
Mention mashlib-dev in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ timbl 2018
 
 ## Local development
 
-For local development, go to [mashlib-deb](https://github.com/inrupt/mashlib-dev).
+For local development, we recommend using [mashlib-dev](https://github.com/inrupt/mashlib-dev) to set up your development environment.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ It is an extensible platform, and is never finished.  Do help!
 timbl 2018
 
 - Here is the [Travis build space](https://travis-ci.org/solid/mashlib/builds)
+
+## Local development
+
+For local development, go to [mashlib-deb](https://github.com/inrupt/mashlib-dev).


### PR DESCRIPTION
Might make it easier for new developers, since trying to setup mashlib standalone results in some errors (e.g. can't login due to no .well-known present).