### PR TITLE
added header menu for #152

### DIFF
--- a/src/global/header.ts
+++ b/src/global/header.ts
@@ -1,6 +1,6 @@
 import { IndexedFormula, NamedNode, sym } from 'rdflib'
 import { authn, widgets } from 'solid-ui'
-import { icon } from './icon'
+import { helpIcon, solidIcon } from './icon'
 import { SolidSession } from '../../typings/solid-auth-client'
 import { emptyProfile } from './empty-profile'
 import { throttle } from '../helpers/throttle'
@@ -29,18 +29,63 @@ async function createBanner (store: IndexedFormula, pod: NamedNode, user: NamedN
   const podLink = document.createElement('a')
   podLink.href = pod.uri
   podLink.classList.add('header-banner__link')
-  podLink.innerHTML = icon
+  podLink.innerHTML = solidIcon
 
-  const menu = user
+  const userMenu = user
     ? await createUserMenu(store, user)
     : createLoginSignUpButtons()
+
+  const helpMenu = createHelpMenu()
 
   const banner = document.createElement('div')
   banner.classList.add('header-banner')
   banner.appendChild(podLink)
-  banner.appendChild(menu)
+
+  const leftSideIfHeader = document.createElement('div')
+  leftSideIfHeader.classList.add('header-banner__right-menu')
+  leftSideIfHeader.appendChild(userMenu)
+  leftSideIfHeader.appendChild(helpMenu)
+
+  banner.appendChild(leftSideIfHeader)
 
   return banner
+}
+
+function createHelpMenu () {
+  const helpMenuList = document.createElement('ul')
+  helpMenuList.classList.add('header-user-menu__list')
+  helpMenuList.appendChild(createUserMenuItem(createUserMenuLink('User guide', 'https://github.com/solid/userguide')))
+  helpMenuList.appendChild(createUserMenuItem(createUserMenuLink('Report a problem', 'https://github.com/solid/solidos/issues')))
+
+  const helpMenu = document.createElement('nav')
+
+  helpMenu.classList.add('header-user-menu__navigation-menu')
+  helpMenu.setAttribute('aria-hidden', 'true')
+  helpMenu.appendChild(helpMenuList)
+
+  const helpMenuContainer = document.createElement('div')
+  helpMenuContainer.classList.add('header-banner__user-menu')
+  helpMenuContainer.classList.add('header-user-menu')
+  helpMenuContainer.appendChild(helpMenu)
+
+  const helpMenuTrigger = document.createElement('button')
+  helpMenuTrigger.classList.add('header-user-menu__trigger')
+  helpMenuTrigger.type = 'button'
+  helpMenuTrigger.innerHTML = helpIcon
+  helpMenuContainer.appendChild(helpMenuTrigger)
+
+  const throttledMenuToggle = throttle((event: Event) => toggleMenu(event, helpMenuTrigger, helpMenu), 50)
+  helpMenuTrigger.addEventListener('click', throttledMenuToggle)
+  let timer = setTimeout(() => null, 0)
+  helpMenuContainer.addEventListener('mouseover', event => {
+    clearTimeout(timer)
+    throttledMenuToggle(event)
+  })
+  helpMenuContainer.addEventListener('mouseout', event => {
+    timer = setTimeout(() => throttledMenuToggle(event), 200)
+  })
+
+  return helpMenuContainer
 }
 
 function createLoginSignUpButtons () {

--- a/src/global/icon.ts
+++ b/src/global/icon.ts
@@ -1,4 +1,4 @@
-export const icon = `
+export const solidIcon = `
 <svg width="352px" height="322px" viewBox="0 0 352 322" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="fadeIn header-banner__icon">
     <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
     <title>To root of Pod</title>
@@ -24,6 +24,24 @@ export const icon = `
                     <path d="M86.5959184,114.932143 L174.258673,202.594898 C180.061224,208.397449 189.454592,208.397449 195.257143,202.594898 L210.453061,187.39898 C216.255612,181.596429 216.255612,172.203061 210.453061,166.40051 L122.816327,78.7377551 C117.013776,72.9352041 107.620408,72.9352041 101.817857,78.7377551 L86.6219388,93.9336735 C80.7673469,99.7362245 80.7673469,109.155612 86.5959184,114.932143 Z" fill="#F7F7F7" fill-rule="nonzero"></path>
                     <polygon fill="#444444" fill-rule="nonzero" opacity="0.3" points="175.689796 204.078061 124.195408 163.954592 135.592347 163.954592"></polygon>
                     <polygon fill="#444444" fill-rule="nonzero" opacity="0.3" points="121.359184 77.2806122 161.925 117.846429 175.689796 117.846429"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>`
+export const helpIcon = `
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="fadeIn header-banner__help-icon">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>help_outline</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Outlined" transform="translate(-782.000000, -288.000000)">
+            <g id="Action" transform="translate(100.000000, 100.000000)">
+                <g id="Outlined-/-Action-/-help_outline" transform="translate(680.000000, 186.000000)">
+                    <g>
+                        <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                        <path d="M11,18 L13,18 L13,16 L11,16 L11,18 Z M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M12,20 C7.59,20 4,16.41 4,12 C4,7.59 7.59,4 12,4 C16.41,4 20,7.59 20,12 C20,16.41 16.41,20 12,20 Z M12,6 C9.79,6 8,7.79 8,10 L10,10 C10,8.9 10.9,8 12,8 C13.1,8 14,8.9 14,10 C14,12 11,11.75 11,15 L13,15 C13,12.75 16,12.5 16,10 C16,7.79 14.21,6 12,6 Z" id="🔹-Icon-Color" fill="#1D1D1D"></path>
+                    </g>
                 </g>
             </g>
         </g>

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -3,6 +3,7 @@ $icon-size: 60px;
 .header-banner {
   @include box-shadow(0px, 1px, 4px, $divider-color);
   display: flex;
+  justify-content: space-between;
   padding: 0 1.5em;
   margin-bottom: 4px;
 
@@ -10,6 +11,12 @@ $icon-size: 60px;
     height: $icon-size;
     width: round($icon-size * 352 / 322);
     width: $icon-size * 352 / 322;
+  }
+
+  &__help-icon {
+    height: $icon-size;
+    width: round($icon-size * 352 / 430);
+    width: $icon-size * 352 / 430;
   }
 
   &__login {
@@ -23,6 +30,10 @@ $icon-size: 60px;
 
   &__link {
     display: block;
+  }
+
+  &__right-menu {
+    display: flex;
   }
 
   &__user-menu {
@@ -86,7 +97,6 @@ $icon-size: 60px;
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    margin: $image-margin;
     height: $image-size;
     width: $image-size;
   }


### PR DESCRIPTION
This PR is for the https://github.com/solid/solid-ui/issues/152 which is in the solid-ui the problem is that the header code is still in mashlib. 
The new header menu looks like:
![Screenshot 2021-10-01 at 15 42 45](https://user-images.githubusercontent.com/4144203/135645573-f150570d-d3f6-4a4a-8adb-95bfebcaf907.png)
an
![Screenshot 2021-10-01 at 15 43 38](https://user-images.githubusercontent.com/4144203/135645609-a04616a1-a9d8-484b-b931-0846f544c6b5.png)
d
When not logged in:
![Screenshot 2021-10-01 at 17 21 23](https://user-images.githubusercontent.com/4144203/135645708-2595c260-852e-435c-9c55-df79b555e919.png)

P.s. This PR is sort of related to https://github.com/solid/solid-ui/pull/433 which needs to be kept in sync with the mashlib header code. 
